### PR TITLE
labelRef should be looking for the input, not a div.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function toggleRandomizedSetting(buttonRef, forId) {
 
 function addRandomizeButton() {
     const counterRef = $(this);
-    const labelRef = $(this).find('div[data-for]');
+    const labelRef = $(this).find('input[data-for]');
     const isDisabled = counterRef.data('randomization-disabled');
 
     if (labelRef.length === 0 || isDisabled == true) {


### PR DESCRIPTION
`$(this)` is already a div and the only child is the input so this would never find anything. Example:
```
<div class="range-block-counter">
     <input type="number" min="0" max="2.0" step="0.01" data-for="temp_openai" id="temp_counter_openai">
</div>
```

